### PR TITLE
Drop containers-basic bundle from the default list.

### DIFF
--- a/scripts/02_add_common_bundles.sh
+++ b/scripts/02_add_common_bundles.sh
@@ -8,5 +8,5 @@ set -o xtrace
 systemctl start boot.mount
 
 swupd bundle-add sysadmin-basic network-basic vim shells containers-basic patch diffutils
-systemctl enable docker
-
+# We are not enabling docker by default as it is not required for all
+# use-cases. Kindly enable the docker service if you wish to use it.


### PR DESCRIPTION
This patch is dropping containers-basic (mainly docker) from the default
image. While docker is used massively across the world, it will not be
used on all scenarios of this image. Also docker muddles with iptable
rules which is not needed for all applications and use-cases. It can
still be installed by running `swupd bundle-add containers-basic` if an
user requires it.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>